### PR TITLE
fix(ci): Mock Tauri dependencies in recipes.repository test

### DIFF
--- a/src/modules/core/recipes/services/__tests__/recipes.repository.test.ts
+++ b/src/modules/core/recipes/services/__tests__/recipes.repository.test.ts
@@ -53,6 +53,30 @@ vi.mock("@/utils/costEngine", async (importOriginal) => {
   };
 });
 
+// Mock finance service to avoid Tauri invoke in tests
+vi.mock("@/modules/core/finance/services/finance.service", () => ({
+  financeService: {
+    calculateStandardCost: vi.fn(async () => ({
+      raw_materials: 2,
+      direct_labor: 3,
+      labor_taxes: 1,
+      prime_cost: 6,
+      variable_overhead: 2,
+      fixed_overhead: 2,
+      total_cost_of_goods: 10,
+      fully_loaded_cost: 10,
+    })),
+  },
+}));
+
+// Mock finance repository
+vi.mock("@/modules/core/finance/services/finance.repository", () => ({
+  financeRepository: {
+    saveRecipeFinancials: vi.fn(async () => undefined),
+    getRecipeFinancials: vi.fn(async () => ({})),
+  },
+}));
+
 describe("RecipesRepository", () => {
   let repository: RecipesRepository;
 


### PR DESCRIPTION
### **User description**
## Problem
The unit test for `RecipesRepository.recalculateCosts()` was failing with:
```
TypeError: Cannot read properties of undefined (reading 'invoke')
at invoke node_modules/`@tauri-apps/api`/core.js:202:39
at Object.calculateStandardCost src/modules/core/finance/services/finance.service.ts:17:25
at RecipesRepository.recalculateCosts src/modules/core/recipes/services/recipes.repository.ts:383:44
```

## Root Cause
The `recalculateCosts` method calls `financeService.calculateStandardCost()`, which invokes the Tauri `invoke` function to communicate with the Rust backend. In the test environment (Vitest with jsdom), Tauri's `invoke` is not available, causing the error.

## Solution
Added Vitest mocks for:
1. **financeService** - Mock `calculateStandardCost()` to return realistic cost breakdown values
2. **financeRepository** - Mock `saveRecipeFinancials()` to prevent database access attempts

These mocks allow the test to verify the business logic without requiring Tauri or database connectivity.

## Changes
- Added `vi.mock()` for `@/modules/core/finance/services/finance.service`
- Added `vi.mock()` for `@/modules/core/finance/services/finance.repository`
- Mocked return values match the expected cost breakdown structure


> AI generated by [CI Failure Doctor](https://github.com/serguei9090/Gusto/actions/runs/22116491271)

<!-- gh-aw-workflow-id: ci-doctor -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Mock Tauri dependencies to fix failing test

- Added mocks for financeService and financeRepository

- Prevents Tauri invoke calls in test environment

- Allows recalculateCosts test to run without native backend


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Environment"] -->|previously failed| B["recalculateCosts"]
  B -->|calls| C["financeService.calculateStandardCost"]
  C -->|requires| D["Tauri invoke"]
  D -->|unavailable| E["Test Error"]
  A -->|now mocks| F["financeService"]
  A -->|now mocks| G["financeRepository"]
  F -->|returns| H["Cost Breakdown"]
  G -->|returns| I["Undefined"]
  B -->|uses mocks| H
  B -->|uses mocks| I
  B -->|succeeds| J["Test Passes"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>recipes.repository.test.ts</strong><dd><code>Mock finance service and repository dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/core/recipes/services/__tests__/recipes.repository.test.ts

<ul><li>Added vi.mock for financeService with calculateStandardCost returning <br>cost breakdown<br> <li> Added vi.mock for financeRepository with saveRecipeFinancials and <br>getRecipeFinancials<br> <li> Mocked return values match expected cost structure with materials, <br>labor, and overhead<br> <li> Prevents Tauri invoke function calls during test execution</ul>


</details>


  </td>
  <td><a href="https://github.com/serguei9090/Gusto/pull/9/files#diff-e872003820254f2e376a32c412e7961db3bebb74e5224a897e4da1d5ab2793b4">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

